### PR TITLE
Deploy the dotnet8 upgraded auth-verify-token function to staging and production in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,19 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
+  node: circleci/node@7.0.0
 
 executors:
   docker-python:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.12
   docker-terraform:
     docker:
       - image: "hashicorp/terraform:0.12.29"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"
@@ -61,29 +61,25 @@ commands:
     parameters:
       stage:
         type: string
+      path:
+        type: string
+        default: "./ApiAuthVerifyToken/"
     steps:
       - *attach_workspace
       - checkout
       - setup_remote_docker
-      - run:
-          name: Install Node.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
-            apt-get update && apt-get install -y nodejs
-      - run:
-          name: Install serverless CLI
-          command: npm i -g serverless
+      - node/install
       - run:
           name: Build lambda
           command: |
-            cd ./ApiAuthVerifyToken/
+            cd <<parameters.path>>
             chmod +x ./build.sh
             ./build.sh
       - run:
           name: Deploy lambda
           command: |
-            cd ./ApiAuthVerifyToken/
-            sls deploy --stage <<parameters.stage>> --conceal
+            cd <<parameters.path>>
+            npx --yes --debug serverless deploy --stage <<parameters.stage>> --conceal
 jobs:
   check-code-formatting:
     executor: docker-dotnet
@@ -102,10 +98,10 @@ jobs:
       - setup_remote_docker
       - run:
           name: build
-          command: docker-compose build api-auth-verify-token-test
+          command: docker compose build api-auth-verify-token-test
       - run:
           name: Run tests
-          command: docker-compose run api-auth-verify-token-test
+          command: docker compose run api-auth-verify-token-test
   terraform-init-and-apply-to-development:
     executor: docker-terraform
     steps:
@@ -153,10 +149,31 @@ jobs:
           stage: "production"
 
 workflows:
+  check:
+    jobs:
+      - check-code-formatting:
+          filters:
+            branches:
+              ignore:
+                - master
+                - development
+      - build-and-test:
+          filters:
+            branches:
+              ignore:
+                - master
+                - development
+
   check-and-deploy-development:
     jobs:
-      - check-code-formatting
-      - build-and-test
+      - check-code-formatting:
+          filters:
+            branches:
+              only: development
+      - build-and-test:
+          filters:
+            branches:
+              only: development
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
@@ -176,6 +193,7 @@ workflows:
           filters:
             branches:
               only: development
+
   check-and-deploy-staging-and-production:
     jobs:
       - build-and-test:
@@ -185,10 +203,10 @@ workflows:
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
-              - build-and-test
+            - build-and-test
           filters:
-             branches:
-               only: master
+            branches:
+              only: master
       - terraform-init-and-apply-to-staging:
           requires:
             - assume-role-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,8 @@ workflows:
       - deploy-to-development:
           requires:
             - assume-role-development
+          context:
+            - "Serverless Framework"
           filters:
             branches:
               only: development
@@ -216,6 +218,8 @@ workflows:
       - deploy-to-staging:
           requires:
             - terraform-init-and-apply-to-staging
+          context:
+            - "Serverless Framework"
           filters:
             branches:
               only: master
@@ -242,6 +246,8 @@ workflows:
       - deploy-to-production:
           requires:
             - terraform-init-and-apply-to-production
+          context:
+            - "Serverless Framework"
           filters:
             branches:
               only: master

--- a/ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
+++ b/ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -14,17 +14,17 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.12">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Bogus" Version="25.0.4" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ApiAuthVerifyToken.Tests/DatabaseTests.cs
+++ b/ApiAuthVerifyToken.Tests/DatabaseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using ApiAuthVerifyToken.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -14,6 +15,7 @@ namespace ApiAuthVerifyToken.Tests
         [SetUp]
         public void RunBeforeAnyTests()
         {
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
             var builder = new DbContextOptionsBuilder();
             builder.UseNpgsql(ConnectionString.TestDatabase());
             DatabaseContext = new TokenDatabaseContext(builder.Options);

--- a/ApiAuthVerifyToken.Tests/Dockerfile
+++ b/ApiAuthVerifyToken.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
@@ -10,12 +10,11 @@ COPY ./ApiAuthVerifyToken.sln ./
 COPY ./ApiAuthVerifyToken/ApiAuthVerifyToken.csproj ./ApiAuthVerifyToken/
 COPY ./ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj ./ApiAuthVerifyToken.Tests/
 
-RUN dotnet restore ./ApiAuthVerifyToken/ApiAuthVerifyToken.csproj
-RUN dotnet restore ./ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
+RUN dotnet restore ApiAuthVerifyToken
+RUN dotnet restore ApiAuthVerifyToken.Tests
 
 # Copy everything else and build
-COPY . .
+COPY . ./
 
 RUN dotnet build -c debug -o out ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
-
-CMD dotnet test
+CMD dotnet test ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj

--- a/ApiAuthVerifyToken.Tests/V1/AcceptanceTests/VerifyTokenAcceptanceTests.cs
+++ b/ApiAuthVerifyToken.Tests/V1/AcceptanceTests/VerifyTokenAcceptanceTests.cs
@@ -40,8 +40,8 @@ namespace ApiAuthVerifyToken.Tests.V1.AcceptanceTests
             _mockAwsStsGateway = new Mock<IAwsStsGateway>();
             _mockDynamoDbGateway = new Mock<IDynamoDbGateway>();
             //set up env vars
-            Environment.SetEnvironmentVariable("jwtSecret", _fixture.Create<string>());
-            Environment.SetEnvironmentVariable("hackneyUserAuthTokenJwtSecret", _faker.Random.AlphaNumeric(25));
+            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(50));
+            Environment.SetEnvironmentVariable("hackneyUserAuthTokenJwtSecret", _faker.Random.AlphaNumeric(50));
             //set up JWT tokens
             _allowedGroups = new List<string> { _faker.Random.Word(), _faker.Random.Word() };
             _jwtServiceFlow = GenerateJwtHelper.GenerateJwtToken();
@@ -91,7 +91,7 @@ namespace ApiAuthVerifyToken.Tests.V1.AcceptanceTests
             var lambdaRequest = _fixture.Build<APIGatewayCustomAuthorizerRequest>().Create();
             lambdaRequest.Headers["Authorization"] = _jwtServiceFlow;
             //change jwt secret to simulate failure of validating token
-            Environment.SetEnvironmentVariable("jwtSecret", _fixture.Create<string>());
+            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(50));
             var result = _classUnderTest.VerifyToken(lambdaRequest);
 
             result.Should().BeOfType<APIGatewayCustomAuthorizerResponse>();

--- a/ApiAuthVerifyToken.Tests/V1/UseCase/VerifyAccessUseCaseTests.cs
+++ b/ApiAuthVerifyToken.Tests/V1/UseCase/VerifyAccessUseCaseTests.cs
@@ -32,8 +32,8 @@ namespace ApiAuthVerifyToken.Tests.V1.UseCase
             _mockAwsStsGateway = new Mock<IAwsStsGateway>();
             _mockDynamoDbGateway = new Mock<IDynamoDbGateway>();
             _classUnderTest = new VerifyAccessUseCase(_mockDatabaseGateway.Object, _mockAwsApiGateway.Object, _mockAwsStsGateway.Object, _mockDynamoDbGateway.Object);
-            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(25));
-            Environment.SetEnvironmentVariable("hackneyUserAuthTokenJwtSecret", _faker.Random.AlphaNumeric(25));
+            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(50));
+            Environment.SetEnvironmentVariable("hackneyUserAuthTokenJwtSecret", _faker.Random.AlphaNumeric(50));
         }
         #region Service Auth Flow
 
@@ -54,7 +54,7 @@ namespace ApiAuthVerifyToken.Tests.V1.UseCase
         {
             var request = GenerateAuthorizerRequest(GenerateJwtHelper.GenerateJwtToken());
             //change key to simulate failed validation
-            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(16));
+            Environment.SetEnvironmentVariable("jwtSecret", _faker.Random.AlphaNumeric(50));
             var result = _classUnderTest.ExecuteServiceAuth(request);
             result.Allow.Should().BeFalse();
             result.User.Should().Be("user");

--- a/ApiAuthVerifyToken.sln
+++ b/ApiAuthVerifyToken.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiAuthVerifyToken", "ApiAuthVerifyToken\ApiAuthVerifyToken.csproj", "{6F482163-3F51-487F-8F7D-37A1D4DAEA8B}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34723.18
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiAuthVerifyToken", "ApiAuthVerifyToken\ApiAuthVerifyToken.csproj", "{6F482163-3F51-487F-8F7D-37A1D4DAEA8B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiAuthVerifyToken.Tests", "ApiAuthVerifyToken.Tests\ApiAuthVerifyToken.Tests.csproj", "{DE8E4E61-EB76-416B-8417-E8F2F6A0C0D3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiAuthVerifyToken.Tests", "ApiAuthVerifyToken.Tests\ApiAuthVerifyToken.Tests.csproj", "{DE8E4E61-EB76-416B-8417-E8F2F6A0C0D3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,5 +21,19 @@ Global
 		{DE8E4E61-EB76-416B-8417-E8F2F6A0C0D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DE8E4E61-EB76-416B-8417-E8F2F6A0C0D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DE8E4E61-EB76-416B-8417-E8F2F6A0C0D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{310A6722-973C-4CAF-952B-EA7CBF4FEC88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{310A6722-973C-4CAF-952B-EA7CBF4FEC88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{310A6722-973C-4CAF-952B-EA7CBF4FEC88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{310A6722-973C-4CAF-952B-EA7CBF4FEC88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{466564FF-AD08-447B-ADAB-BB8A9395D9E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{466564FF-AD08-447B-ADAB-BB8A9395D9E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{466564FF-AD08-447B-ADAB-BB8A9395D9E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{466564FF-AD08-447B-ADAB-BB8A9395D9E0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {041ABF76-4241-466B-9034-59E4C0520DCC}
 	EndGlobalSection
 EndGlobal

--- a/ApiAuthVerifyToken/ApiAuthVerifyToken.csproj
+++ b/ApiAuthVerifyToken/ApiAuthVerifyToken.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     </PropertyGroup>
 
@@ -18,21 +18,22 @@
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.12" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.9" />
+    <PackageReference Include="JWT" Version="11.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.12">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
   </ItemGroup>
 
 </Project>

--- a/ApiAuthVerifyToken/ConfigureServices.cs
+++ b/ApiAuthVerifyToken/ConfigureServices.cs
@@ -17,6 +17,8 @@ namespace ApiAuthVerifyToken
 
             var connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING");
 
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+
             services.AddDbContext<TokenDatabaseContext>(
                 opt => opt.UseNpgsql(connectionString));
 

--- a/ApiAuthVerifyToken/Dockerfile
+++ b/ApiAuthVerifyToken/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 WORKDIR /app
 

--- a/ApiAuthVerifyToken/V1/Helpers/ValidateTokenHelper.cs
+++ b/ApiAuthVerifyToken/V1/Helpers/ValidateTokenHelper.cs
@@ -1,39 +1,56 @@
 using Amazon.Lambda.Core;
-using Microsoft.IdentityModel.Tokens;
-using System;
+using JWT;
+using JWT.Algorithms;
+using JWT.Exceptions;
+using JWT.Serializers;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
-using System.Text;
 
 namespace ApiAuthVerifyToken.V1.Helpers
 {
     public static class ValidateTokenHelper
     {
+        private static readonly JwtDecoder _decoder;
+
+        static ValidateTokenHelper()
+        {
+            var algorithm = new HMACSHA256Algorithm();
+            var serializer = new JsonNetSerializer();
+            var validator = new JwtValidator(serializer, new UtcDateTimeProvider());
+            var urlEncoder = new JwtBase64UrlEncoder();
+
+            _decoder = new JwtDecoder(serializer, validator, urlEncoder, algorithm);
+        }
+
         public static List<Claim> ValidateToken(string token, string secret)
         {
             try
             {
-                JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+                // System.IdentityModel.Tokens.Jwt fails to decode the token because JWT 
+                // doesn't contain a "KID" header I couldn't find a workaround for this 
+                // issue, so I switched to the JWT (https://www.nuget.org/packages/JWT) 
+                // package to verify the tokens
+                var tokenJson = _decoder.Decode(token, secret, verify: true);
+                if (tokenJson == null) return null;
 
-                var handler = new JwtSecurityTokenHandler();
-                var validations = new TokenValidationParameters
-                {
-                    ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(secret)),
-                    ValidateIssuer = false,
-                    ValidateAudience = false,
-                    RequireExpirationTime = false
-                };
-                var claims = handler.ValidateToken(token, validations, out var tokenSecure);
-                return claims.Claims.ToList();
+                return ExtractClaims(token);
             }
-            catch (SecurityTokenInvalidSignatureException)
+            catch (SignatureVerificationException)
             {
                 LambdaLogger.Log($"Token beginning with {token.Substring(0, 8)} is not valid");
-                return null; //token invalid, return null
+                return null;
             }
+        }
+
+        private static List<Claim> ExtractClaims(string token)
+        {
+            // To avoid changing the interface, the previous implementation using 
+            // JwtSecurityTokenHandler still works great for extracting the Claims from the JWT
+            var handler = new JwtSecurityTokenHandler();
+            var parsedToken = handler.ReadToken(token) as JwtSecurityToken;
+            return parsedToken?.Claims.ToList() ?? new List<Claim>();
         }
     }
 }

--- a/ApiAuthVerifyToken/V1/Helpers/VerifyAccessHelper.cs
+++ b/ApiAuthVerifyToken/V1/Helpers/VerifyAccessHelper.cs
@@ -21,13 +21,13 @@ namespace ApiAuthVerifyToken.V1.Helpers
             {
                 LambdaLogger.Log($"Token with id {tokenData.Id} denying access for {tokenData.ApiName} with endpoint {tokenData.ApiEndpointName}" +
                    $" in {tokenData.Environment} stage does not have access to {apiName} with endpoint {authorizerRequest.ApiEndpointName} " +
-                   $"for {authorizerRequest.Environment} stage { tokenData.Enabled }");
+                   $"for {authorizerRequest.Environment} stage {tokenData.Enabled}");
                 return false;
             }
 
             LambdaLogger.Log($"Token with id {tokenData.Id} allowing access for {tokenData.ApiName} with endpoint {tokenData.ApiEndpointName}" +
                    $" in {tokenData.Environment} stage has access to {apiName} with endpoint {authorizerRequest.ApiEndpointName} " +
-                   $"for {authorizerRequest.Environment} stage { tokenData.Enabled }");
+                   $"for {authorizerRequest.Environment} stage {tokenData.Enabled}");
 
             return true;
         }

--- a/ApiAuthVerifyToken/build.cmd
+++ b/ApiAuthVerifyToken/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/api-auth-verify-token.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package bin/release/net8.0/api-auth-verify-token.zip

--- a/ApiAuthVerifyToken/build.sh
+++ b/ApiAuthVerifyToken/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/api-auth-verify-token.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/api-auth-verify-token.zip

--- a/ApiAuthVerifyToken/serverless.yml
+++ b/ApiAuthVerifyToken/serverless.yml
@@ -1,16 +1,16 @@
-service: api-auth-verify-token
+service: api-auth-verify-token-new
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet8
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
 package:
-  artifact: ./bin/release/netcoreapp3.1/api-auth-verify-token.zip
+  artifact: ./bin/release/net8.0/api-auth-verify-token.zip
 
 functions:
-  ApiAuthVerifyToken:
-    name: ${self:service}-${self:provider.stage}-apiauthverifytoken
+  ApiAuthVerifyTokenNew:
+    name: ${self:service}-${self:provider.stage}-apiauthverifytokennew
     handler: ApiAuthVerifyToken::ApiAuthVerifyToken.V1.Boundary.VerifyTokenHandler::VerifyToken
     role: lambdaExecutionRole
     environment:
@@ -20,14 +20,93 @@ functions:
       AWS_ROLE_NAME_FOR_STS_API_GATEWAY_GET: ${ssm:/api-auth-token-generator/${self:provider.stage}/sts-role-name}
 
 resources:
+  Conditions:
+    CreateDRPolicies: !Equals
+      - ${self:provider.stage}
+      - "production"
+
   Resources:
+    AllowApisAccountAuthorizer:
+      # ProductionApis or StagingApis
+      Type: AWS::Lambda::Permission
+      Properties:
+        FunctionName:
+          Fn::GetAtt:
+            - ApiAuthVerifyTokenNewLambdaFunction
+            - Arn
+        Action: lambda:InvokeFunction
+        Principal: apigateway.amazonaws.com
+        SourceArn:
+          Fn::Join:
+            - ""
+            - - "arn:aws:execute-api:"
+              - Ref: AWS::Region
+              - ":"
+              - Ref: AWS::AccountId
+              - ":*"
+    AllowHousingCrossAccountAuthorizer:
+      # Housing-Production or Housing-Staging
+      Type: AWS::Lambda::Permission
+      Properties:
+        FunctionName:
+          Fn::GetAtt:
+            - ApiAuthVerifyTokenNewLambdaFunction
+            - Arn
+        Action: lambda:InvokeFunction
+        Principal: apigateway.amazonaws.com
+        SourceArn:
+          Fn::Join:
+            - ""
+            - - "arn:aws:execute-api:"
+              - Ref: AWS::Region
+              - ":"
+              - ${self:custom.housingAccountIds.${self:provider.stage}}
+              - ":*/authorizers/*"
+    AllowDRCrossAccountAuthorizer:
+      # Disaster-recovery (prod only)
+      Condition: CreateDRPolicies
+      Type: AWS::Lambda::Permission
+      Properties:
+        FunctionName:
+          Fn::GetAtt:
+            - ApiAuthVerifyTokenNewLambdaFunction
+            - Arn
+        Action: lambda:InvokeFunction
+        Principal: apigateway.amazonaws.com
+        SourceArn:
+          Fn::Join:
+            - ""
+            - - "arn:aws:execute-api:"
+              - Ref: AWS::Region
+              - ":"
+              - ${self:custom.disasterRecoveryAccountIds.production}
+              - ":*/authorizers/*"
+    assumeRoleForDRPolicy:
+      Type: AWS::IAM::Policy
+      Condition: CreateDRPolicies
+      Properties:
+        PolicyName: assumeRoleForGettingCredentialsDRAccount
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - "sts:AssumeRole"
+              Resource:
+                Fn::Join:
+                  - ""
+                  - - "arn:aws:iam::"
+                    - ${self:custom.disasterRecoveryAccountIds.production}
+                    - ":role/LBH_Api_Gateway_Allow_GET"
+        Roles:
+          - Ref: lambdaExecutionRole
     lambdaExecutionRole:
       Type: AWS::IAM::Role
       Properties:
         Path: /${self:service}/${self:provider.stage}/
         RoleName: ${self:service}-lambdaExecutionRole
         AssumeRolePolicyDocument:
-          Version: '2012-10-17'
+          Version: "2012-10-17"
           Statement:
             - Effect: Allow
               Principal:
@@ -39,7 +118,7 @@ resources:
         Policies:
           - PolicyName: manageLogs
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
@@ -47,32 +126,24 @@ resources:
                     - logs:CreateLogStream
                     - logs:PutLogEvents
                   Resource:
-                    - 'Fn::Join':
-                        - ':'
-                        - - 'arn:aws:logs'
-                          - Ref: 'AWS::Region'
-                          - Ref: 'AWS::AccountId'
-                          - 'log-group:/aws/lambda/*:*:*'
-                - Effect: "Allow"
-                  Action:
-                    - "s3:PutObject"
-                    - "s3:GetObject"
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - "arn:aws:s3:::"
-                        - "Ref": "ServerlessDeploymentBucket"
+                    - "Fn::Join":
+                        - ":"
+                        - - "arn:aws:logs"
+                          - Ref: "AWS::Region"
+                          - Ref: "AWS::AccountId"
+                          - "log-group:/aws/lambda/*:*:*"
           - PolicyName: lambdaInvocation
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
                     - "lambda:InvokeFunction"
                   Resource: "*"
-          - PolicyName: assumeRoleForGettingCredentials
+          - PolicyName: assumeRoleForGettingCredentialsApiAccount
+            # ProductionApis or StagingApis
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
@@ -80,11 +151,26 @@ resources:
                   Resource:
                     Fn::Join:
                       - ""
-                      - - "arn:aws:iam:::"
-                        - "role/LBH_Api_Gateway_Allow_GET"
+                      - - "arn:aws:iam::"
+                        - Ref: "AWS::AccountId"
+                        - ":role/LBH_Api_Gateway_Allow_GET"
+          - PolicyName: assumeRoleForGettingCredentialsHousingAccount
+            # Housing-Production or Housing-Staging
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - "sts:AssumeRole"
+                  Resource:
+                    Fn::Join:
+                      - ""
+                      - - "arn:aws:iam::"
+                        - ${self:custom.housingAccountIds.${self:provider.stage}}
+                        - ":role/LBH_Api_Gateway_Allow_GET"
           - PolicyName: getAPIGatewayAPIName
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
@@ -92,7 +178,7 @@ resources:
                   Resource: "*"
           - PolicyName: dynamoDBAccess
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
@@ -103,13 +189,18 @@ resources:
                     - "dynamodb:Query"
                     - "dynamodb:Scan"
                   Resource:
-                    - 'Fn::Join':
-                        - ':'
-                        - - 'arn:aws:dynamodb'
-                          - Ref: 'AWS::Region'
-                          - Ref: 'AWS::AccountId'
-                          - 'table/APIAuthenticatorData'
+                    - "Fn::Join":
+                        - ":"
+                        - - "arn:aws:dynamodb"
+                          - Ref: "AWS::Region"
+                          - Ref: "AWS::AccountId"
+                          - "table/APIAuthenticatorData"
 custom:
+  housingAccountIds:
+    staging: "087586271961"
+    production: "282997303675"
+  disasterRecoveryAccountIds:
+    production: "851725205572"
   vpc:
     development:
       securityGroupIds:

--- a/ApiAuthVerifyToken/serverless.yml
+++ b/ApiAuthVerifyToken/serverless.yml
@@ -197,6 +197,7 @@ resources:
                           - "table/APIAuthenticatorData"
 custom:
   housingAccountIds:
+    development: "364864573329"
     staging: "087586271961"
     production: "282997303675"
   disasterRecoveryAccountIds:

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 .PHONY: setup
 setup:
-	docker-compose build
+	docker compose build
 
 .PHONY: build
 build:
-	docker-compose build base-api
+	docker compose build base-api
 
 .PHONY: serve
 serve:
-	docker-compose build base-api && docker-compose up base-api
+	docker compose build base-api && docker compose up base-api
 
 .PHONY: shell
 shell:
-	docker-compose run base-api bash
+	docker compose run base-api bash
 
 .PHONY: test
 test:
-	docker-compose up test-database & docker-compose build base-api-test && docker-compose up base-api-test
+	docker compose build api-auth-verify-token-test && docker compose up api-auth-verify-token-test
 
 .PHONY: lint
 lint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     links:
       - test-database
       - dynamodb-database
+
   test-database:
     image: test-database
     build:


### PR DESCRIPTION
See #67 for the main functional changes. We want to deploy a dotnet 8 version of our lambda authorizer in parallel with our dotnet 3 one and switch services from the old to the new one by one.

This is a way to upgrade it to dotnet 8 with reduced risk, as this is a critical part of almost all of our housing APIs.