### PR TITLE
Revert "Fix lambda execution role"

### DIFF
--- a/ApiAuthVerifyToken/serverless.yml
+++ b/ApiAuthVerifyToken/serverless.yml
@@ -115,8 +115,8 @@ resources:
     lambdaExecutionRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: /api-auth-verify-token/${self:provider.stage}/
-        RoleName: api-auth-verify-token-lambdaExecutionRole
+        Path: /${self:service}/${self:provider.stage}/
+        RoleName: ${self:service}-lambdaExecutionRole
         AssumeRolePolicyDocument:
           Version: "2012-10-17"
           Statement:


### PR DESCRIPTION
Reverts LBHackney-IT/api-auth-verify-token#77 - that's not how this works, it seems