### PR TITLE
Use runsettings to allow setting test env vars

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.unitTests.runSettingsPath": "ApiAuthVerifyToken.Tests/.runsettings"
+}

--- a/ApiAuthVerifyToken.Tests/.docker.runsettings
+++ b/ApiAuthVerifyToken.Tests/.docker.runsettings
@@ -1,0 +1,16 @@
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <DB_USERNAME>postgres</DB_USERNAME>
+      <DB_HOST>test-database</DB_HOST>
+      <DB_PORT>5432</DB_PORT>
+      <DB_PASSWORD>mypassword</DB_PASSWORD>
+      <DB_DATABASE>devdb</DB_DATABASE>
+      <DynamoDb_LocalMode>true</DynamoDb_LocalMode>
+      <DynamoDb_LocalServiceUrl>http://dynamodb-database:8000</DynamoDb_LocalServiceUrl>
+      <AWS_REGION>eu-west-2</AWS_REGION>
+      <AWS_ACCESS_KEY_ID>local</AWS_ACCESS_KEY_ID>
+      <AWS_SECRET_ACCESS_KEY>local</AWS_SECRET_ACCESS_KEY>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/ApiAuthVerifyToken.Tests/.runsettings
+++ b/ApiAuthVerifyToken.Tests/.runsettings
@@ -1,0 +1,16 @@
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <DB_USERNAME>postgres</DB_USERNAME>
+      <DB_HOST>localhost</DB_HOST>
+      <DB_PORT>5432</DB_PORT>
+      <DB_PASSWORD>mypassword</DB_PASSWORD>
+      <DB_DATABASE>devdb</DB_DATABASE>
+      <DynamoDb_LocalMode>true</DynamoDb_LocalMode>
+      <DynamoDb_LocalServiceUrl>http://localhost:8000</DynamoDb_LocalServiceUrl>
+      <AWS_REGION>eu-west-2</AWS_REGION>
+      <AWS_ACCESS_KEY_ID>local</AWS_ACCESS_KEY_ID>
+      <AWS_SECRET_ACCESS_KEY>local</AWS_SECRET_ACCESS_KEY>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
+++ b/ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
@@ -9,6 +9,10 @@
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)/.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />

--- a/ApiAuthVerifyToken.Tests/Dockerfile
+++ b/ApiAuthVerifyToken.Tests/Dockerfile
@@ -17,4 +17,4 @@ RUN dotnet restore ApiAuthVerifyToken.Tests
 COPY . ./
 
 RUN dotnet build -c debug -o out ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
-CMD dotnet test ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj
+CMD dotnet test ApiAuthVerifyToken.Tests/ApiAuthVerifyToken.Tests.csproj --settings ApiAuthVerifyToken.Tests/.docker.runsettings

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ shell:
 test:
 	docker compose build api-auth-verify-token-test && docker compose up api-auth-verify-token-test
 
+test-raw:
+	# requires db dockers running
+	dotnet test
+
 .PHONY: lint
 lint:
 	-dotnet tool install -g dotnet-format

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,17 +24,6 @@ services:
     build:
       context: .
       dockerfile: ApiAuthVerifyToken.Tests/Dockerfile
-    environment:
-      - DB_HOST=test-database
-      - DB_PORT=5432
-      - DB_USERNAME=postgres
-      - DB_PASSWORD=mypassword
-      - DB_DATABASE=testdb
-      - DynamoDb_LocalMode=true
-      - DynamoDb_LocalServiceUrl=http://dynamodb-database:8000
-      - AWS_REGION=eu-west-2
-      - AWS_ACCESS_KEY_ID=local
-      - AWS_SECRET_ACCESS_KEY=local
     links:
       - test-database
       - dynamodb-database


### PR DESCRIPTION
This is to simplify debugging the unit tests with the correct environment variables.

NUnit does not allow setting and getting environment variables in test setup, so .runsettings was the simplest other approach.

Ideally we'd have a full MockWebApplicationFactory but this is a simpler solution for now.

A key problem is that the env vars for Docker and non-docker test runs are different - the db hosts, so 2 runsettings files are needed. The default is for running without docker, and the Dockerfile points to the docker one `.docker.runsettings`