### PR TITLE
Update codeowners to include HPT

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/targeted-services @LBHackney-IT/housing-products
+* @LBHackney-IT/targeted-services, @LBHackney-IT/housing-products

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/targeted-services
+* @LBHackney-IT/targeted-services @LBHackney-IT/housing-products

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/targeted-services, @LBHackney-IT/housing-products
+* @LBHackney-IT/targeted-services, * @LBHackney-IT/housing-products

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/targeted-services, * @LBHackney-IT/housing-products
+* @LBHackney-IT/targeted-services @LBHackney-IT/housing-products


### PR DESCRIPTION
This repo is shared between housing and targeted services products.

It's important for the housing product team to be able to quickly revert changes as needed also.