### PR TITLE
TS-2076 Add pre production workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,47 @@ references:
       at: *workspace_root
 
 commands:
+  terraform-init-then-plan:
+    description: "Initializes and run plan from terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+          name: get and init
+      - run:
+          name: plan
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform plan -out=plan.out
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
+            - project/*
+  terraform-apply:
+    description: "Runs Terraform Apply"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          name: apply
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform apply -auto-approve plan.out
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"
     parameters:
@@ -117,6 +158,16 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "production"
+  terraform-init-and-plan-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
+          environment: "pre-production"
+  terraform-apply-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-apply:
+          environment: "pre-production"
   assume-role-development:
     executor: docker-python
     steps:
@@ -132,6 +183,11 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
+  assume-role-pre-production:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_PRE_PRODUCTION
   deploy-to-development:
     executor: docker-dotnet
     steps:
@@ -147,6 +203,11 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "production"
+  deploy-to-pre-production:
+    executor: docker-dotnet
+    steps:
+      - deploy-lambda:
+          stage: "pre-production"
 
 workflows:
   check:
@@ -248,6 +309,73 @@ workflows:
             - terraform-init-and-apply-to-production
           context:
             - "Serverless Framework"
+          filters:
+            branches:
+              only: master
+
+  deploy-terraform-pre-production:
+    jobs:
+      - permit-pre-production-terraform-workflow:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
+          requires:
+            - permit-pre-production-terraform-workflow
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-plan-pre-production:
+          requires:
+            - assume-role-pre-production
+          filters:
+            branches:
+              only: master
+      - permit-pre-production-terraform-deployment:
+          type: approval
+          requires:
+            - terraform-init-and-plan-pre-production
+          filters:
+            branches:
+              only: master
+      - terraform-apply-pre-production:
+          requires:
+            - permit-pre-production-terraform-deployment
+          filters:
+            branches:
+              only: master
+
+  deploy-code-pre-production:
+    jobs:
+      - permit-pre-production-code-workflow:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - build-and-test:
+          requires:
+            - permit-pre-production-code-workflow
+          context: 
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              only: master
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
+      - deploy-to-pre-production:
+          context:
+          - api-nuget-token-context
+          - "Serverless Framework"
+          requires:
+            - assume-role-pre-production        
           filters:
             branches:
               only: master

--- a/ApiAuthVerifyToken/serverless.yml
+++ b/ApiAuthVerifyToken/serverless.yml
@@ -243,3 +243,8 @@ custom:
       subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34
+    pre-production:
+      subnetIds:
+        - subnet-08aa35159a8706faa
+        - subnet-0b848c5b14f841dfb
+

--- a/terraform/pre-production/aws_ssm_parameter.tf
+++ b/terraform/pre-production/aws_ssm_parameter.tf
@@ -1,0 +1,88 @@
+
+locals {
+  environment = "pre-production"
+}
+
+resource "aws_ssm_parameter" "postgres_hostname" {
+  name  = "api-auth-token-generator/${local.environment}/postgres-hostname"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "postgres_port" {
+  name  = "api-auth-token-generator/${local.environment}/postgres-port"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "postgres_username" {
+  name  = "api-auth-token-generator/${local.environment}/postgres-username"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "postgres_password" {
+  name  = "api-auth-token-generator/${local.environment}/postgres-password"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "token_secret" {
+  name  = "api-auth-token-generator/${local.environment}/token-secret"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "hackney_jwt_secret" {
+  name  = "common/hackney-jwt-secret"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "sts_role_name" {
+  name  = "api-auth-token-generator/${local.environment}/sts-role-name"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/terraform/pre-production/main.tf
+++ b/terraform/pre-production/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+terraform {
+  backend "s3" {
+    bucket         = "housing-pre-production-terraform-state"
+    encrypt        = true
+    region         = "eu-west-2"
+    key            = "services/api-authenticator/state"
+    dynamodb_table = "housing-pre-production-terraform-state-lock"
+  }
+}
+
+resource "aws_dynamodb_table" "api_authenticator_dynamodb_table" {
+  name         = "APIAuthenticatorData"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "apiName"
+  range_key    = "environment"
+
+  attribute {
+    name = "apiName"
+    type = "S"
+  }
+  attribute {
+    name = "environment"
+    type = "S"
+  }
+
+  tags = {
+    Name              = "api-authenticator-pre-production"
+    Environment       = "prod"
+    terraform-managed = true
+    project_name      = "api-authenticator"
+    Application       = "MTFH Housing Pre-Production"
+    TeamEmail         = "developementteam@hackney.gov.uk"
+    BackupPolicy      = "prod"
+    Confidentiality   = "Internal"
+  }
+
+  global_secondary_index {
+    name            = "apiGatewayIdIndex"
+    hash_key        = "apiGatewayId"
+    projection_type = "ALL"
+  }
+
+  attribute {
+    name = "apiGatewayId"
+    type = "S"
+  }
+}


### PR DESCRIPTION
This update adds a workflow to deploy the authorizer and the related DynamoDB table to housing-pre-production account.

i didn't want to touch the existing flows at all for safety, so created new jobs to terrafom plan and apply which are then used by the new workflows.

Terraform and code workflows run in parallel and won't do anything unless manually approved.

I've also added the intial parameter store values required by the lambda to the terraform config for easier maintenance and re-deployment.

 